### PR TITLE
Rails 3.1.3 was throwing error, path was not being added to sprockets load path.

### DIFF
--- a/lib/cacheable_flash/rails/engine.rb
+++ b/lib/cacheable_flash/rails/engine.rb
@@ -2,12 +2,7 @@
 #   This gem contains this empty engine class which inherits from Rails::Engine.
 #   By doing this, Rails is informed that the directory for this gem may contain assets and the
 #   app/assets, lib/assets and vendor/assets directories of this engine are added to the search path of Sprockets.
-module Jquery
-  module Rails
-
-    class Engine < ::Rails::Engine
-
-    end
-
+module CacheableFlash
+  class Engine < ::Rails::Engine
   end
 end


### PR DESCRIPTION
Rails 3.1.3 was throwing error, path was not being added to sprockets load path.

This fixes it.

/opt/ruby-enterprise-1.8.7-2011.03/bin/ruby /opt/ruby-enterprise-1.8.7-2011.03/lib/ruby/gems/1.8/bin/rake assets:precompile:all RAILS_ENV=production RAILS_GROUPS=assets
rake aborted!
couldn't find file 'flash.js'
  (in /u/apps/can_send/dev/app/assets/javascripts/application.js:13)

Tasks: TOP => assets:precompile:primary
(See full trace by running task with --trace)
rake aborted!
Command failed with status (1): [/opt/ruby-enterprise-1.8.7-2011.03/bin/rub...]

Tasks: TOP => assets:precompile
(See full trace by running task with --trace)
