### PR TITLE
Removed unneeded type check

### DIFF
--- a/lib/cacheable_flash.rb
+++ b/lib/cacheable_flash.rb
@@ -31,7 +31,7 @@ module CacheableFlash
 
     flash.each do |key, value|
       if cookie_flash[key.to_s].blank?
-        cookie_flash[key.to_s] = value.kind_of?(Numeric) ? value.to_s : value
+        cookie_flash[key.to_s] = value.to_s
       else
         cookie_flash[key.to_s] << "<br/>#{value}"
       end


### PR DESCRIPTION
The type check is not needed because the .to_s is implicit since the curly brackets are used in the else case.

I needed to use a TrueClass as a value it gave me an "undefined method `<<' for true:TrueClass (NoMethodError)" everytime I used write_flash_to_cookie.
