### PR TITLE
Escape HTML in flash values unless they're html_safe

### DIFF
--- a/lib/cacheable_flash.rb
+++ b/lib/cacheable_flash.rb
@@ -30,6 +30,7 @@ module CacheableFlash
     end
 
     flash.each do |key, value|
+      value = ERB::Util.html_escape(value) unless value.is_a?(Hash) || value.html_safe?
       if cookie_flash[key.to_s].blank?
         cookie_flash[key.to_s] = value.kind_of?(Numeric) ? value.to_s : value
       else

--- a/spec/cacheable_flash/cacheable_flash_spec.rb
+++ b/spec/cacheable_flash/cacheable_flash_spec.rb
@@ -95,6 +95,18 @@ describe 'CacheableFlash' do
 
       @controller.flash.should == {}
     end
+    
+    it "escapes HTML if the flash value is not html safe" do
+      @controller.flash = { 'quantity' => "<div>foobar</div>" }
+      @controller.write_flash_to_cookie
+      JSON(@controller.cookies['flash']).should == { 'quantity' => "&lt;div&gt;foobar&lt;/div&gt;" }
+    end
+    
+    it "does not escape flash HTML if the value is html safe" do
+      @controller.flash = { 'quantity' => '<div>foobar</div>'.html_safe }
+      @controller.write_flash_to_cookie
+      JSON(@controller.cookies['flash']).should == { 'quantity' => "<div>foobar</div>" }
+    end
   end
 
   describe ".included" do


### PR DESCRIPTION
Flash values were not HTML escaped and that may expose a XSS vulnerability.
Rails 3 automatically does this for us unless we mark the string as html_safe so I added the same behaviour to cacheable-flash.
Hashes and their values are untouched and treated as html_safe.
