### PR TITLE
Make Cacheable flash available as a Rack middleware

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,3 +1,4 @@
+
 = CacheableFlash
 
 == Description
@@ -5,7 +6,8 @@
 This plugin enables greater levels of page caching by rendering flash
 messages from a cookie using JavaScript, instead of in your Rails
 view template.  Flash contents are converted to JSON and placed in
-a cookie by an after_filter in a controller.
+a cookie by an after_filter in a controller or a Rack middleware in
+your application.
 
 == Installation as plugin
 
@@ -54,9 +56,10 @@ Please help document!
 
 https://github.com/pivotal/cacheable-flash/wiki
 
-=== Usage
+== Usage as an around filter
 
-To use, include the CacheableFlash module in your controller.
+To use as an around filter, include the CacheableFlash module
+in your controller.
 It's all or none on the actions in your controller, so you can't
 mix JS and HTML display of your flash message in a controller.
 No other modifications to the controller are needed.  You will need
@@ -69,12 +72,27 @@ as happens normally).
 
 === Example Controller
 
-class MyController < ActionController::Base
-  include CacheableFlash
-  # ...
-end
+  class MyController < ActionController::Base
+    include CacheableFlash
+    # ...
+  end
 
-=== Example Template Markup
+== Usage as a Rack middleware (requires Rails 3)
+
+To use as a Rack Middleware, swap the Rails flash middleware with the
+Cacheable flash middleware.
+Use this method if you set flash messages inside a rescue_from block:
+
+  rescue_from CanCan::AccessDenied do |exception|
+    redirect_to root_url, :alert => exception.message
+  end
+
+=== In your application.rb:
+
+  # Swap the ActionDispatch::Flash middleware with the CacheableFlash one
+  config.middleware.swap ActionDispatch::Flash, CacheableFlash::Middleware
+
+== Example Template Markup
 
   <div id="error_div_id" class="flash flash_error"></div>
   <div id="notice_div_id" class="flash flash_notice"></div>

--- a/lib/cacheable_flash/cookie_flash.rb
+++ b/lib/cacheable_flash/cookie_flash.rb
@@ -1,0 +1,15 @@
+module CookieFlash
+  def cookie_flash(flash, cookies)
+    cookie_flash = (JSON(cookies['flash']) if cookies['flash']) || {} rescue {}
+
+    flash.each do |key, value|
+      value = ERB::Util.html_escape(value) unless value.is_a?(Hash) || value.html_safe?
+      if cookie_flash[key.to_s].blank?
+        cookie_flash[key.to_s] = value.kind_of?(Numeric) ? value.to_s : value
+      else
+        cookie_flash[key.to_s] << "<br/>#{value}"
+      end
+    end
+    cookie_flash.to_json.gsub("+", "%2B")
+  end
+end

--- a/lib/cacheable_flash/middleware.rb
+++ b/lib/cacheable_flash/middleware.rb
@@ -1,0 +1,26 @@
+module CacheableFlash
+  class Middleware
+    require 'cacheable_flash/cookie_flash'
+    include CookieFlash
+    FLASH_HASH_KEY = "action_dispatch.request.flash_hash".freeze
+
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      status, headers, body = @app.call(env)
+      flash = env[FLASH_HASH_KEY]
+
+      if flash
+        response = Rack::Response.new(body, status, headers)
+
+        cookies = env["rack.cookies"] || {}
+        response.set_cookie("flash", { :value => cookie_flash(flash, cookies), :path => "/" })
+        response.finish
+      else
+        [status, headers, body]
+      end
+    end
+  end
+end


### PR DESCRIPTION
When setting the flash in a rescue_from the flash messages are not being written to the cookie because the rescue_from will set the flash after write_flash_to_cookie is called (if it is called at all, as it won't be called when the exception occurs before).

For example:

  class ApplicationController < ActionController::Base
    rescue_from CanCan::AccessDenied do |exception|
      redirect_to root_url, :alert => exception.message
    end
  end

In this case, the flash message from the rescue_from will only be processed in the following request.

Making cacheable flash write the flash to the cookie using a Rack middleware ensures that the flash is written to the cookie after all filters and rescue_from handlers are run.

It works by swapping the ActionDispatch::Flash middleware with its own CacheableFlash middleware. This is optional (and in no way enforced), and serves to avoid unnecessary processing by the ActionDispatch::Flash middleware.

This new approach only applies to Rails 3 and so, developers must explicitly enable it. If they don't, cacheable_flash will work as before - with an around_filter - therefore it will not break existing applications.

We've also changed the README to include this usage.

This pull request is the result of the combined efforts of [Telmo Costa](https://github.com/telmofcosta), [Duarte Henriques](https://github.com/dsgh) and myself.
