### PR TITLE
Completely removes Rails version checks

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -1,6 +1,2 @@
 require "json"
 require "cacheable_flash"
-#use Rails::VERSION::STRING for rails < 1 somehow -- or perhaps, who cares??
-if ::Rails::VERSION::MAJOR == 2
-  ActionView::Helpers::AssetTagHelper.register_javascript_include_default('jquery.cookie','flash')
-end

--- a/lib/cacheable_flash.rb
+++ b/lib/cacheable_flash.rb
@@ -2,18 +2,9 @@ require 'json'
 require 'stackable_flash'
 
 module CacheableFlash
-  if defined?(Rails) && (::Rails::VERSION::MAJOR == 3 || ::Rails.VERSION::MAJOR > 3)
-    require 'cacheable_flash/middleware'
-
-    # Since rails 3.0 doesn't have engine support
-    if (::Rails::VERSION::MAJOR == 3 && ::Rails::VERSION::MAJOR >= 1) || ::Rails.VERSION::MAJOR > 3
-      require 'cacheable_flash/engine'
-    end
-
-    require 'cacheable_flash/railtie'
-  else
-    # For older rails use generator
-  end
+  require 'cacheable_flash/middleware'
+  require 'cacheable_flash/engine'
+  require 'cacheable_flash/railtie'
 
   # By default stacking is false, but it can be turned on with:
   # CacheableFlash.configure do |config|

--- a/lib/cacheable_flash/engine.rb
+++ b/lib/cacheable_flash/engine.rb
@@ -1,10 +1,5 @@
 module CacheableFlash
   class Engine < ::Rails::Engine
-    # Allow for Rails versions ~> 3.1 and > 3
-    if (::Rails::VERSION::MAJOR == 3 && ::Rails::VERSION::MAJOR >= 1) || ::Rails.VERSION::MAJOR > 3
-      isolate_namespace CacheableFlash
-    else
-      warn 'CacheableFlash namespace not isolated, check that Rails version is >= 3.1'
-    end
+    isolate_namespace CacheableFlash
   end
 end

--- a/lib/cacheable_flash/railtie.rb
+++ b/lib/cacheable_flash/railtie.rb
@@ -1,11 +1,8 @@
 # Add cacheable flash JS to defaults for Rails < 3.1 (not needed with asset pipeline)
 module CacheableFlash
   class Railtie < ::Rails::Railtie
-    # Allow for future versions of rails (e.g. rails 4 beta)
-    if ::Rails::VERSION::MAJOR >= 3
-      config.before_configuration do
-        config.action_view.javascript_expansions[:cacheable_flash] = %w(jquery.cookie flash)
-      end
+    config.before_configuration do
+      config.action_view.javascript_expansions[:cacheable_flash] = %w(jquery.cookie flash)
     end
   end
 end

--- a/lib/generators/cacheable_flash/install/install_generator.rb
+++ b/lib/generators/cacheable_flash/install/install_generator.rb
@@ -8,15 +8,8 @@ module CacheableFlash
   #
   class InstallGenerator < Rails::Generators::Base
     source_root File.expand_path('../../../../../vendor/assets/javascripts/', __FILE__)
-
-    # Rails 3.1 has the asset pipeline, no need to copy javascript files anymore
-    # Rails 3.0 doesn't have an asset pipeline, so we copy in javascript files
     desc "Copies some JS files to public/javascripts/"
     def copy_files
-      # Also raose this deprecation in rails 4
-      if (::Rails::VERSION::MAJOR == 3 && ::Rails::VERSION::MINOR == 1) || ::Rails::VERSION::MAJOR > 3
-        ActiveSupport::Deprecation.warn("Rails 3.1 has the asset pipeline, so you only need to copy javascript files if you aren't using it.")
-      end
       template 'flash.js',     'public/javascripts/flash.js'
       template 'jquery.cookie.js', 'public/javascripts/jquery.cookie.js'
     end


### PR DESCRIPTION
This now completely reuires a modern version of Rails (3+).
This PR will be evaluated as CacheableFlash approaches a 1.0 release.
