### PR TITLE
fix JS error when flash cookie is not set (new version of jquery.cookie ...

### DIFF
--- a/vendor/assets/javascripts/flash.js.erb
+++ b/vendor/assets/javascripts/flash.js.erb
@@ -4,7 +4,7 @@ var Flash = new Object();
 Flash.data = {};
 
 Flash.transferFromCookies = function() {
-  var data = JSON.parse(unescape($.cookie("flash")));
+  var data = JSON.parse(unescape($.cookie("flash") || '{}'));
   if(!data) data = {};
   Flash.data = data;
   $.cookie('flash', null, {path: '/', domain: '<%=CacheableFlash::Config.config[:domain]%>'});


### PR DESCRIPTION
Newer version of jQuery.cookie return `undefined` when a cookie is not found, resulting in an exception when flash.js tries to parse a nonexistent flash cookie. 

This simple patch should prevent that error when a newer jQuery.cookie is loaded.

For reference, the symptom is:

`SyntaxError: Unexpected token u`
