### PR TITLE
Insert content as HTML and not plain text

### DIFF
--- a/vendor/assets/javascripts/flash.js.erb
+++ b/vendor/assets/javascripts/flash.js.erb
@@ -15,7 +15,7 @@ Flash.writeDataTo = function(name, element, callback) {
   var message = "";
   if (Flash.data[name]) {
     message = Flash.data[name].toString().replace(/\+/g, ' ');
-    element.text(message);
+    element.html(message);
     if (callback && typeof(callback) === 'function') {
       callback(element);
     } else {


### PR DESCRIPTION
This was the cause of html_safe strings still showing html content. Fixes #36.